### PR TITLE
Remove double encoding fix to prevent XSS

### DIFF
--- a/src/Console/Database/FixHtmlEncodingCommand.php
+++ b/src/Console/Database/FixHtmlEncodingCommand.php
@@ -337,8 +337,6 @@ final class FixHtmlEncodingCommand extends AbstractCommand
     {
         $new_value = $item->fields[$field];
 
-        $new_value = $this->doubleEncoding($new_value);
-
         if (in_array($item::getType(), [Ticket::getType(), ITILFollowup::getType()]) && $field == 'content') {
             $new_value = $this->fixEmailHeadersEncoding($new_value);
         }
@@ -346,28 +344,6 @@ final class FixHtmlEncodingCommand extends AbstractCommand
         $new_value = $this->fixQuoteEntityWithoutSemicolon($new_value);
 
         return $new_value;
-    }
-
-    /**
-     * Remove double encoding of HTML tags:
-     * - character < is encoded &#38;lt; but should be encoded &#60;
-     * - character > is encoded &#38;gt; but should be encoded &#62;
-     *
-     * @param string $input
-     * @return string
-     */
-    private function doubleEncoding(string $input): string
-    {
-        // Prepare the double encoding fix of HTML tag
-        $pattern = [
-            '/&#38;lt;/', // Opening tag
-            '/&#38;gt;/', // closing tag
-        ];
-        $replace = [
-            '&#60;',
-            '&#62;',
-        ];
-        return preg_replace($pattern, $replace, $input);
     }
 
     /**
@@ -469,8 +445,6 @@ final class FixHtmlEncodingCommand extends AbstractCommand
         global $DB;
 
         $searches = [
-            [$field => ['LIKE', '%&#38;lt;%']],
-            [$field => ['LIKE', '%&#38;gt;%']],
             [$field => ['LIKE', '%&quot(?!;)/%']],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -

While testing the command, I figured out that the "double encoding" fix may alter elements that were intentionnally encoded twice. 

For instance, this 
![image](https://user-images.githubusercontent.com/33253653/207554703-46c5e2fe-33a9-461e-aa4e-a86334baad40.png)
will be transformed by
![image](https://user-images.githubusercontent.com/33253653/207560582-df07a404-fe44-4315-b108-c8024d9d9799.png)

Problem is that, if content is displayed by an application through API, or is sent in notifications and viewed using a webmail application, it can result in security issues.

I know customer for whom we produce the command had some double encoding issues, but I guess it would be preferable to remove the double encoding fix as it is likely to be harmful.